### PR TITLE
#11 

### DIFF
--- a/ACadSvg/ConversionContext.cs
+++ b/ACadSvg/ConversionContext.cs
@@ -6,26 +6,73 @@
 #endregion
 
 
+using ACadSharp.Tables;
+
+
 namespace ACadSvg {
 
-	public class ConversionContext {
+    /// <summary>
+    /// The conversion context contains various informations provided by the calling
+    /// application. The <see cref="ConversionOptions"/> determine various details of
+    /// the conversion process. The <see cref="ConversionInfo"/> receives the
+	/// conversion log and the summary of occurring entities. 
+	/// <see cref="ViewboxData"/> and <see cref="GlobalAttributeData"/> provide setting
+	/// required for building the SVG element for the display in an application and for
+	/// the output as SVG file.
+	/// The internal <see cref="BlocksInDefs"/> property contains the list of converted
+	/// <see cref="BlockRecord"/> objects that is filled during the conversion.
+    /// </summary>
+    public class ConversionContext {
 
-		public BlockRecordsSvg BlocksInDefs { get; } = new BlockRecordsSvg();
+		/// <summary>
+		/// Gets a <see cref="BlockRecordsSvg"/> object containing a list of
+		/// <see cref="BlockRecordSvg"/> objects representing the <see cref="BlockRecord"/>
+		/// objects found in the AutoCAD document and <see cref="PatternSvg"/> objects
+		/// used by <see cref="HatchSvg"/> objects. This list is filled during the
+		/// conversion.
+		/// </summary>
+		internal BlockRecordsSvg BlocksInDefs { get; } = new BlockRecordsSvg();
 
 
-		public ConversionInfo ConversionInfo { get; } = new ConversionInfo();
+        /// <summary>
+        /// Gets a <see cref="ACadSvg.ConversionInfo"/> object receifing the conversion
+        /// log and the summary of occurring entities.
+        /// </summary>
+        public ConversionInfo ConversionInfo { get; } = new ConversionInfo();
 
 
-		public ConversionOptions ConversionOptions { get; set; }
+		/// <summary>
+		/// Gets or sets a <see cref="ACadSvg.ConversionOptions"/> object providing
+		/// various options for the conversion process.
+		/// </summary>
+		public ConversionOptions ConversionOptions { get; set; } = new ConversionOptions();
 
 
-		public ViewboxData ViewboxData { get; set; }
+        /// <summary>
+        /// Gets or sets a <see cref="ACadSvg.ViewboxData"/> object providung data for an
+        /// optional <i>viewbox</i> attribute for the <i>svg</i> element.
+        /// </summary>
+        public ViewboxData ViewboxData { get; set; } = new ViewboxData();
 
 
-		public GlobalAttributeData GlobalAttributeData { get; set; }
+		/// <summary>
+		/// Gets or sets a <see cref="ACadSvg.GlobalAttributeData"/> object providing various
+		/// setings to create attributes for the main group and the <i>svg</i> element.
+		/// </summary>
+		public GlobalAttributeData GlobalAttributeData { get; set; } = new GlobalAttributeData();
 
 
-		public void UpdateSettings(ConversionOptions conversionOptions, ViewboxData viewboxData, GlobalAttributeData globalAttributeData) {
+		/// <summary>
+		/// Updates the <see cref="ACadSvg.ConversionOptions"/>, <see cref="ACadSvg.ViewboxData"/>,
+		/// and <see cref="ACadSvg.GlobalAttributeData"/> of this <see cref="ConversionContext"/>.
+		/// </summary>
+		/// <param name="conversionOptions"></param>
+		/// <param name="viewboxData"></param>
+		/// <param name="globalAttributeData"></param>
+		public void UpdateSettings(
+			ConversionOptions conversionOptions,
+			ViewboxData viewboxData,
+			GlobalAttributeData globalAttributeData) {
 			ConversionOptions = conversionOptions;
 			ViewboxData = viewboxData;
 			GlobalAttributeData = globalAttributeData;

--- a/ACadSvg/ConversionInfo.cs
+++ b/ACadSvg/ConversionInfo.cs
@@ -41,7 +41,7 @@ namespace ACadSvg {
 			/// </summary>
 			Skipped,
 			/// <summary>
-			/// The conversion of an entity could not be supressed because
+			/// The conversion of an entity could not be processed because
 			/// the entity is not supported by ACadSharp.
 			/// </summary>
 			NotSupported
@@ -72,11 +72,26 @@ namespace ACadSvg {
 		public SortedSet<string> OccurringEntities { get; } = new SortedSet<string>();
 
 
-		/// <summary>
-		/// Gets the complete log from the last converion.
-		/// </summary>
-		/// <returns></returns>
-		public string GetLog() {
+        /// <summary>
+        /// Gets the logged of <see cref="OccurringEntities"/> as string.
+        /// </summary>
+        /// <returns>
+        /// A multiline string containing the log logged occurring entities.
+        /// </returns>
+        public string GetOccurringEntitiesLog() {
+			StringBuilder sb = new StringBuilder();
+			foreach (string entity in OccurringEntities) {
+				sb.AppendLine(entity);
+			}
+			return sb.ToString();
+		}
+
+
+        /// <summary>
+        /// Returns the log from the last conversion.
+        /// </summary>
+        /// <returns>A multiline string containing the log entries.</returns>
+        public string GetLog() {
 			return _logSb.ToString();
 		}
 

--- a/ACadSvg/ConversionOptions.cs
+++ b/ACadSvg/ConversionOptions.cs
@@ -8,20 +8,63 @@
 
 namespace ACadSvg {
 
-	public class ConversionOptions {
+    /// <summary>
+    /// Provides providing various options for the conversion process.
+    /// </summary>
+    public class ConversionOptions {
 
-		public bool ReverseY {  get; set; } = true;
+        /// <summary>
+        /// Get or sets a value indication that the y-direction is to be reversed, i.e.
+        /// y-coordinates grow from bottom to top.
+        /// </summary>
+        /// <remarks>
+        /// In the SVG coordinate system y grows from top to bottom.
+        /// This option allows to reverse the y-coodinates so that y grows from bottom
+        /// to top and AutoCAD coordinates can be used as they are delivered.
+        /// </remarks>
+        /// <value>
+        /// <b>true</b>, when the y-direction is to be reversed; otherwise, <b>false</b>.
+        /// </value>
+        public bool ReverseY {  get; set; } = true;
 
 
+        /// <summary>
+        /// Gets or sets a value indicating that an <i>id</i> attribute is to be created 
+        /// for every converted AutoCAD Entity from the entity handle (Hex).
+        /// </summary>
+        /// <value>
+        /// <b>true</b>, when a<i>id</i> attributes are to be created; otherwise, <b>false</b>.
+        /// </value>
 		public bool ExportHandleAsID { get; set; } = true;
 
 
+        /// <summary>
+        /// Gets or sets a value indicating that a <i>class</i>-attribute is to created
+        /// for every converted AutoCAD Entity from the name of the entity's layer.
+        /// </summary>
+        /// <value>
+        /// <b>true</b>, when <i>class</i>-attributes are to created; otherwise, <b>false</b>.
+        /// </value>
 		public bool ExportLayerAsClass { get; set; } = true;
 
 
+        /// <summary>
+        /// Gets or sets a value indicating that a <i>class</i>>-attribute is to be created
+        /// for every converted AutoCAD Entity from the object type.
+        /// </summary>
+        /// <value>
+        /// <b>true</b>, when <i>class</i>>-attributes are to be created; otherwise, <b>false</b>.
+        /// </value>
 		public bool ExportObjectTypeAsClass { get; set; } = true;
 
 
-		public bool EnableComments { get; set; } = true;
+        /// <summary>
+        /// Gets or sets a value indicating that a comment is to be created
+        /// for every converted AutoCAD Entity. This option is not yet implemented.
+        /// </summary>
+        /// <value>
+        /// <b>true</b>, when ; otherwise, <b>false</b>.
+        /// </value>
+		public bool EnableComments { get; set; } = false;
 	}
 }

--- a/ACadSvg/GlobalAttributeData.cs
+++ b/ACadSvg/GlobalAttributeData.cs
@@ -40,30 +40,5 @@ namespace ACadSvg {
 
 
 		public double Rotation {  get; set; }
-
-
-		public GlobalAttributeData(
-            bool strokeEnabled,
-            Color strokeColor,
-            double strokeWidth,
-            bool fillEnabled,
-            Color fillColor,
-            double transX,
-            double transY,
-            double scaleX,
-            double scaleY,
-            double rot) {
-
-			StrokeEnabled = strokeEnabled;
-			Stroke = strokeColor.Name;
-			StrokeWidth = strokeWidth;
-			FillEnabled = fillEnabled;
-			Fill = fillColor.Name;
-			TransX = transX;
-			TransY = transY;
-			ScaleX = scaleX;
-			ScaleY = scaleY;
-			Rotation = rot;
-        }
 	}
 }

--- a/ACadSvg/ViewboxData.cs
+++ b/ACadSvg/ViewboxData.cs
@@ -7,20 +7,42 @@
 
 
 namespace ACadSvg {
+
+    /// <summary>
+    /// Provides a xmin, y-min, width and height for an optional <i>viewbox</i> attribute
+    /// to be added to the <i>svg</i> element. 
+    /// </summary>
     public class ViewboxData {
 
-        public bool Enabled { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicates that a <i>viewbox</i> attribute is to added to the
+        /// <i>svg</i> element.
+        /// </summary>
+        /// <value><b>true</b>, when an <i>viewbox</i> attribute is to be added; otherwise, <b>false</b>.</value>
+        public bool Enabled { get; set; } = false;
 
 
-        public double MinX { get; set; }
+        /// <summary>
+        /// Gets or sets the min-x value for the <i>viewbox</i> attribute.
+        /// </summary>
+        public double MinX { get; set; } = 0;
 
 
-        public double MinY { get; set; }
+        /// <summary>
+        /// Gets or sets the min-y value for the <i>viewbox</i> attribute.
+        /// </summary>
+        public double MinY { get; set; } = 0;
 
 
-        public double Width { get; set; }
+        /// <summary>
+        /// Gets or sets the width value for the <i>viewbox</i> attribute.
+        /// </summary>
+        public double Width { get; set; } = 1000;
 
 
-        public double Height { get; set; }
+        /// <summary>
+        /// Gets or sets the height value for the <i>viewbox</i> attribute.
+        /// </summary>
+        public double Height { get; set; } = 1000;
     }
 }


### PR DESCRIPTION
-  Comments
-  ConversionContext: BlocksInDefs should be internal, all context-Objects are initializes for the use in a console application.
-  ConversionInfo: new Method GetOccurringEntitiesLog(),
-  GloabalAtttributeData constructor without parameters.
-  ConversionOption.EnableComments initialized with false.