### PR TITLE
Implementation of measurement formatters

### DIFF
--- a/ACadSvg/DimensionTextFormatter/AngularMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/AngularMeasurementFormatter.cs
@@ -1,0 +1,176 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+using ACadSharp.Types.Units;
+
+using ACadSvg.Extensions;
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// The base class for angular formatters used by angular dimension entities.
+    /// The text created contains a value part with or without tolerance, but no
+    /// alternate-unit value. Various formatters according to the specified
+    /// <see cref="DimensionProperties.AngularUnitFormat"/> can be created with the
+    /// <see cref="CreateMeasurementFormatter"/> method.
+    /// </summary>
+    internal abstract class AngularMeasurementFormatter : MeasurementFormatterBase {
+
+        /// <summary>
+        /// Initializes a new instance of an angular measurement formatter.
+        /// </summary>
+        /// <param name="dimension">The<see cref="Dimension"/> object the dimension text is to be created for.</param>
+        /// <param name="dimProps">A <see cref="DimensionProperties"/> object providing all
+        /// dimension-style properties specufied in the <see cref="DimensionStyle"/> object
+        /// associated with the dimension object possibly overriden by the dimension object's
+        /// extended data.</param>
+        /// <param name="defaultPostFix">A string specifying a default prefix and/or postfix
+        /// used for both the primary and the alternate value if no prefix/postfix is specified
+        /// by the dimension-style properties.</param>
+        /// <remarks>
+        /// </remarks>
+        protected AngularMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Creates a new instance of an angular measurement formatter as specified by the
+        /// <paramref name="format"/> parameter. 
+        /// </summary>
+        /// <param name="dimension">The<see cref="Dimension"/> object the dimension text is to be created for.</param>
+        /// <param name="dimProps">A <see cref="DimensionProperties"/> object providing all
+        /// dimension-style properties specufied in the <see cref="DimensionStyle"/> object
+        /// associated with the dimension object possibly overriden by the dimension object's
+        /// extended data.</param>
+        /// <returns>
+        /// An angular measurement formatter as specified by the <paramref name="format"/>
+        /// parameter. The returned formatter can be a <see cref="DecimalDegreesMeasurementFormatter"/>,
+        /// <see cref="RadiansMeasurementFormatter"/>, <see cref="GradiansMeasurementFormatter"/>,
+        /// <see cref="SurveyorUnitsMeasurementFormatter"/>, or <see cref="DegreesMinutesSecondsMeasurementFormatter"/>.
+        /// </returns>
+        public static AngularMeasurementFormatter CreateMeasurementFormatter(
+            AngularUnitFormat format,
+            Dimension dimension,
+            DimensionProperties dimProps,
+            double textSize) {
+
+            switch (format) {
+            default:
+            case AngularUnitFormat.DecimalDegrees:
+                return new DecimalDegreesMeasurementFormatter(dimension, dimProps, "<>°", textSize);
+
+            case AngularUnitFormat.Radians:
+                return new RadiansMeasurementFormatter(dimension, dimProps, "<>r", textSize);
+
+            case AngularUnitFormat.Gradians:
+                return new GradiansMeasurementFormatter(dimension, dimProps, "<>g", textSize);
+
+            case AngularUnitFormat.SurveyorsUnits:
+                return new SurveyorUnitsMeasurementFormatter(dimension, dimProps, "<>", textSize);
+
+            case AngularUnitFormat.DegreesMinutesSeconds:
+                return new DegreesMinutesSecondsMeasurementFormatter(dimension, dimProps, "<>", textSize);
+            }
+        }
+
+
+        /// <summary>
+        /// When implemented in a derived class scales the angle value in radians from AutoCAD
+        /// to the specific angular unit.
+        /// </summary>
+        /// <param name="value">The angle value in radians as specified by AutoCAD.</param>
+        /// <returns>The scaled value.</returns>
+        protected abstract double GetDisplayValue(double value);
+
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// The measurement value
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularAcaledTo"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularFormattedAs"]'/>
+        /// <see cref="DimensionProperties.AngularDimensionDecimalPlaces"/> and
+        /// <see cref="DimensionProperties.AngularZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>.
+        /// </remarks>
+        public override string FormatMeasurement() {
+            double measurement = GetDisplayValue(_dimension.Measurement);
+            string degsText = FormatValue(measurement, _dimProps.AngularDimensionDecimalPlaces, _dimProps.AngularZeroHandling);
+            return GetTextWithPostFix(degsText);
+        }
+
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// The <see cref="DimensionProperties.PlusTolerance"/> value
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularScaledTo"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularFormattedAs"]'/>
+        /// <see cref="DimensionProperties.ToleranceDecimalPlaces"/> and
+        /// <see cref="DimensionProperties.ToleranceZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>.
+        /// </remarks>
+        public override string FormatMeasurementToleranceSymmetric() {
+            double tolerance = GetDisplayValue(_dimProps.PlusTolerance);
+            string degsText = FormatValue(tolerance, _dimProps.ToleranceDecimalPlaces, _dimProps.ToleranceZeroHandling);
+            return "±" + GetTextWithPostFix(degsText);
+        }
+
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// <see cref="DimensionProperties.PlusTolerance" />, <see cref="DimensionProperties.MinusTolerance" /> values 
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularScaledToPlural"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularFormattedAs"]'/>
+        /// <see cref="DimensionProperties.ToleranceDecimalPlaces"/> and
+        /// <see cref="DimensionProperties.ToleranceZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>
+        /// to both.
+        /// </remarks>
+        public override string FormatMeasurementTolerancePlusMinus() {
+            double minusTolerance = GetDisplayValue(_dimProps.MinusTolerance);
+            double plusTolerance = GetDisplayValue(_dimProps.PlusTolerance);
+
+            short toleranceDecimalPlaces = _dimProps.ToleranceDecimalPlaces;
+            ZeroHandling toleranceZeroHandling = _dimProps.ToleranceZeroHandling;
+            string minusToleranceFormatted = FormatValue(minusTolerance, toleranceDecimalPlaces, toleranceZeroHandling);
+            string plusToleranceFormatted = FormatValue(plusTolerance, toleranceDecimalPlaces, toleranceZeroHandling);
+
+            return FormatToleranceStacked(
+                "-" + GetTextWithPostFix(minusToleranceFormatted),
+                "+" + GetTextWithPostFix(plusToleranceFormatted));
+        }
+
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// The limits
+        /// (Measurement + <see cref="DimensionProperties.PlusTolerance" /> and
+        /// Measumreent - <see cref="DimensionProperties.MinusTolerance" />)
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularScaledToPlural"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="angularFormattedAs"]'/>
+        /// <see cref="DimensionProperties.ToleranceDecimalPlaces"/> and
+        /// <see cref="DimensionProperties.ToleranceZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>
+        /// to both.
+        /// </remarks>
+        public override string FormatMeasurementLimits() {
+            double minValue = GetDisplayValue(_dimension.Measurement - _dimProps.MinusTolerance);
+            double maxValue = GetDisplayValue(_dimension.Measurement + _dimProps.PlusTolerance);
+
+            short decimalPlaces = _dimProps.AngularDimensionDecimalPlaces;
+            ZeroHandling zeroHandling = _dimProps.ZeroHandling;
+            string minLimitFormatted = FormatValue(minValue, decimalPlaces, zeroHandling);
+            string maxLimitFormatted = FormatValue(maxValue, decimalPlaces, zeroHandling);
+
+            return FormatToleranceStacked(
+                GetTextWithPostFix(minLimitFormatted),
+                GetTextWithPostFix(maxLimitFormatted));
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/ArchitecturalMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/ArchitecturalMeasurementFormatter.cs
@@ -1,0 +1,48 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using System.Diagnostics.Metrics;
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+	/// <summary>
+	/// Represents an architectural-measurement formatter for linear dimensions. The measuement
+	/// value specified in inches is to be formatted as feets, integer-inches value, and a
+	/// fraction.
+	/// </summary>
+    internal class ArchitecturalMeasurementFormatter : LinearMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArchitecturalMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc />
+        public ArchitecturalMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Formats the specified value (in inches) as feets and inches, and the fractional
+        /// part of the inches as fraction
+        /// (see <see cref="MeasurementFormatterBase.FormatInchesToFeetInchesFractional"/>.
+        /// </summary>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameterFraction"]/*'/>
+        /// <returns>
+        /// The formatted value with feet, integer inches, and fraction.
+        /// </returns>
+        /// <inheritdoc />
+        protected override string FormatValue(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            return FormatInchesToFeetInchesFractional(value, decimalPlaces, zeroHandling);
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/DecimalDegreesMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/DecimalDegreesMeasurementFormatter.cs
@@ -1,0 +1,55 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using System.Diagnostics.Metrics;
+using System.Globalization;
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+using SvgElements;
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for angular dimensions. The angle value is formatted as
+    /// decimal degrees.
+    /// </summary>
+    internal class DecimalDegreesMeasurementFormatter : AngularMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DecimalDegreesMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc />
+        public DecimalDegreesMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Scales the specified angle value from AutoCAD to degrees.
+        /// </summary>
+        /// <param name="value">The angle value in radians as specified by AutoCAD.</param>
+        /// <returns>The angle in degrees.</returns>
+        protected override double GetDisplayValue(double value) {
+            return value * 180 / Math.PI;
+        }
+
+
+        /// <summary>
+        /// Formats the passed <paramref name="value"/> as decimal number
+        /// <see cref="<see cref="MeasurementFormatterBase.FormatDecimal(double, short, ZeroHandling)"/>.
+        /// </summary>
+        /// <inheritdoc/>
+        /// <returns>A string with the value formatted as decimal expression.</returns>
+        protected override string FormatValue(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            return FormatDecimal(value, decimalPlaces, zeroHandling);
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/DecimalMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/DecimalMeasurementFormatter.cs
@@ -1,0 +1,44 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for linear measurements. The value is formatted as
+    /// a decimal number.
+    /// </summary>
+    internal class DecimalMeasurementFormatter : LinearMeasurementFormatter {
+
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="DecimalMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc/>
+        public DecimalMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Formats the specified value as decimal number
+        /// (see <see cref="MeasurementFormatterBase.FormatDecimal"/>).
+        /// </summary>
+        /// <returns>
+        /// The formatted value as decimal number.
+        /// </returns>
+        /// <inheritdoc/>
+        protected override string FormatValue(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            return FormatDecimal(value, decimalPlaces, zeroHandling);
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/DegreesMinutesSecondsMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/DegreesMinutesSecondsMeasurementFormatter.cs
@@ -1,0 +1,94 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for angular dimensions. The angle value is formatted as
+    /// degrees, minutes and seconds.
+    /// </summary>
+    internal class DegreesMinutesSecondsMeasurementFormatter : AngularMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DegreesMinutesSecondsMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc />
+        public DegreesMinutesSecondsMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Scales the specified angle value from AutoCAD to degrees.
+        /// </summary>
+        /// <param name="value">The angle value in radians as specified by AutoCAD.</param>
+        /// <returns>The angle in degrees.</returns>
+        protected override double GetDisplayValue(double value) {
+            return value * 180 / Math.PI;
+        }
+
+
+        /// <summary>
+        /// Formats an angular value specified in degrees as degrees, minutes an seconds.
+        /// </summary>
+        /// <param name="value">An angular value in degrees.</param>
+        /// <param name="decimalPlaces">controls whether minutes and seconds are displayed
+        /// at all an how many fractional digits are dieplayed at the seconds part:
+        /// <para>
+        /// 0: Only the degrees part is visible.
+        /// </para>
+        /// <para>
+        /// 1, 2: degrees and rounded minutes.
+        /// </para>
+        /// <para>
+        /// 3, 4: degrees, minutes, and rounded seconds.
+        /// </para>
+        /// <para>
+        /// >4: degrees, minutes, and seconds with (decimalPlaces - 4) fractional digits.
+        /// </para>
+        /// </param>
+        /// <returns>
+        /// The formatted value with feet degrees, munutes and seconds.
+        /// </returns>
+        /// <inheritdoc/>
+        protected override string FormatValue(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            switch (decimalPlaces) {
+            case 0:
+                //  No minutes, seconds, degrees rounded to integer
+                return $"{FormatDecimal(value, 0, zeroHandling)}°";
+            case 1:
+            case 2:
+                //  No seconds, minutes rounded to integer
+                {
+                double intDegrees = Math.Floor(value);
+                    double minutes = (value - intDegrees) * 60.0;
+                    string strMinutes = FormatDecimal(minutes, 0, zeroHandling);
+                    return $"{intDegrees}°{strMinutes}'";
+                }
+            default:
+                //  decimalPlaces = 3, 4: degrees, minutes, seconds rounded to integer 
+                //  decimalPlaces > 4: degrees, minutes, seconds rounded with decimalPLaces - 4 fractional digits. 
+                {
+                    double intDegrees = Math.Floor(value);
+                    double minutes = (value - intDegrees) * 60.0;
+                    double intMinutes = Math.Floor(minutes);
+                    double seconds = (minutes - intMinutes) * 60.0;
+                    short secDecimalPlaces = decimalPlaces == 3 ? (short)0 : (short)(decimalPlaces - 4);
+                    string strSeconds = FormatDecimal(seconds, secDecimalPlaces, zeroHandling);
+
+                    return $"{intDegrees}°{intMinutes}'{strSeconds}\"";
+                }
+            }
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/EngineeringMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/EngineeringMeasurementFormatter.cs
@@ -1,0 +1,42 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a measurement formatter for linear dimensions. The value in inches is
+    /// formatted as feet and inches as decimal number.
+    /// </summary>
+	internal class EngineeringMeasurementFormatter : LinearMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EngineeringMeasurementFormatter"/>
+        /// </summary>
+        /// <inheritdoc />
+        public EngineeringMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+			: base(dimension, dimProps, defaultPostFix, textSize) {
+		}
+
+
+        /// <summary>
+        /// Formats the specified value (in inches) as feet and inches as decimal number
+        /// (see <see cref="MeasurementFormatterBase.FormatInchesToFeetInchesFractional"/>.
+        /// </summary>
+        /// <returns>
+        /// The formatted value with feet and inches as decimal number.
+        /// </returns>
+        /// <inheritdoc />
+        protected override string FormatValue(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            return FormatInchesToFeetInchesDecimal(value, decimalPlaces, zeroHandling);
+        }
+	}
+}

--- a/ACadSvg/DimensionTextFormatter/FractionalMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/FractionalMeasurementFormatter.cs
@@ -1,0 +1,44 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for linear measurements. The value is formatted as
+    /// as integer part and fraction.
+    /// </summary>
+    internal class FractionalMeasurementFormatter : LinearMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="FractionalMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc/>
+        public FractionalMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Formats the value as integer part and fraction.
+        /// (see <see cref="FormatFractional"/>).
+        /// </summary>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameterFraction"]/*'/>
+        /// <returns>
+        /// The formatted value with integer part and fraction.
+        /// </returns>
+        /// <inheritdoc/>
+        protected override string FormatValue(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            return FormatFractional(value, decimalPlaces, zeroHandling);
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/GradiansMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/GradiansMeasurementFormatter.cs
@@ -1,0 +1,39 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for angular dimensions. The angle value is formatted as
+    /// decimal gradians (The full circle is assumed to be 400g).
+    /// </summary>
+    internal class GradiansMeasurementFormatter : DecimalDegreesMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GradiansMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc/>
+        public GradiansMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Scales the specified angle value from AutoCAD to gradians.
+        /// </summary>
+        /// <param name="value">The angle value in radians as specified by AutoCAD.</param>
+        /// <returns>The angle in gradians.</returns>
+        protected override double GetDisplayValue(double value) {
+            return value * 200 / Math.PI;
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/LinearMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/LinearMeasurementFormatter.cs
@@ -1,0 +1,325 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+using ACadSharp.Types.Units;
+
+using ACadSvg.Extensions;
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// The base class for linear formatters used by linear dimension entities.
+    /// The text created contains a value part with or without tolerance and optionally an
+    /// alternate-unit value with or without tolerance. Various formatters according to the
+    /// specified <see cref="DimensionProperties.LinearUnitFormat"/> can be created with the
+    /// for linear dimension <see cref="CreateMeasurementFormatter"/> method.
+    /// </summary>
+    internal abstract class LinearMeasurementFormatter : MeasurementFormatterBase {
+
+        /// <summary>
+        /// Initializes a new instance of an linear measurement formatter.
+        /// </summary>
+        /// <param name="dimension">The<see cref="Dimension"/> object the dimension text is to be created for.</param>
+        /// <param name="dimProps">A <see cref="DimensionProperties"/> object providing all
+        /// dimension-style properties specified in the <see cref="DimensionStyle"/> object
+        /// associated with the dimension object possibly overriden by the dimension object's
+        /// extended data.</param>
+        /// <param name="defaultPostFix">A string specifying a default prefix and/or postfix
+        /// used for both the primary and the alternate value if no prefix/postfix is specified
+        /// by the dimension-style properties.</param>
+        /// <remarks>
+        /// </remarks>
+        protected LinearMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Creates a new instance of an linear measurement formatter as specified by the
+        /// <paramref name="format"/> parameter. 
+        /// </summary>
+        /// <param name="dimension">The<see cref="Dimension"/> object the dimension text is to be created for.</param>
+        /// <param name="dimProps">A <see cref="DimensionProperties"/> object providing all
+        /// dimension-style properties specufied in the <see cref="DimensionStyle"/> object
+        /// associated with the dimension object possibly overriden by the dimension object's
+        /// extended data.</param>
+        /// <param name="defaultPostFix">A string specifying a default prefix and/or postfix
+        /// used for both the primary and the alternate value if no prefix/postfix is specified
+        /// by the dimension-style properties.</param>
+        /// <returns>
+        /// An angular measurement formatter as specified by the <paramref name="format"/>
+        /// parameter. The returned formatter can be a <see cref="DecimalMeasurementFormatter"/>,
+        /// <see cref="EngineeringMeasurementFormatter"/>, <see cref="ScientificMeasurementFormatter"/>,
+        /// <see cref="FractionalMeasurementFormatter"/>, <see cref="ArchitecturalMeasurementFormatter"/>,
+        /// or <see cref="WindowsDesktopMeasurementFormatter"/>.
+        /// </returns>
+        public static LinearMeasurementFormatter CreateMeasurementFormatter(
+            LinearUnitFormat format,
+            Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize) {
+
+            switch (format) {
+            default:
+            case LinearUnitFormat.Decimal:
+                return new DecimalMeasurementFormatter(dimension, dimProps, defaultPostFix, textSize);
+
+            case LinearUnitFormat.Engineering:
+                return new EngineeringMeasurementFormatter(dimension, dimProps, defaultPostFix, textSize);
+
+            case LinearUnitFormat.Scientific:
+                return new ScientificMeasurementFormatter(dimension, dimProps, defaultPostFix, textSize);
+
+            case LinearUnitFormat.Fractional:
+                return new FractionalMeasurementFormatter(dimension, dimProps, defaultPostFix, textSize);
+
+            case LinearUnitFormat.Architectural:
+                return new ArchitecturalMeasurementFormatter(dimension, dimProps, defaultPostFix, textSize);
+
+            case LinearUnitFormat.WindowsDesktop:
+                return new WindowsDesktopMeasurementFormatter(dimension, dimProps, defaultPostFix, textSize);
+            }
+        }
+
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Measuement
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearScaledAndRoundedTo"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.DecimalPlaces"/>
+        /// <see cref="DimensionProperties.ZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>
+        /// </remarks>
+        public override string FormatMeasurement() {
+            double measurement = GetValueScaledAndRounded(_dimension.Measurement);
+            string m = FormatValue(measurement, _dimProps.DecimalPlaces, _dimProps.ZeroHandling);
+            return GetTextWithPostFix(m);
+        }
+
+
+        /// <summary>
+        /// Formats the alternate-unit measurement value The formatted numerical value is prefixed and/or
+        /// suffixed as specified by the <see cref="DimensionProperties.PostFix"/> style property.
+        /// If no PostFix style property is specified the default Postfix specified for this formatter
+        /// is used.
+        /// <returns>A string containing the formatted alternate-unit measurement value.</returns>
+        /// <remarks>
+        /// Measuement
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearAlternateScaledAndRoundedTo"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.AlternateUnitDecimalPlaces"/>
+        /// <see cref="DimensionProperties.AlternateUnitZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="alternatePostFix"]'/>
+        /// </remarks>
+        public virtual string FormatAlternate() {
+            double alternateMeasurement = GetAlternateValueScaledAndRounded(_dimension.Measurement);
+            string m = FormatValue(alternateMeasurement, _dimProps.AlternateUnitDecimalPlaces, _dimProps.AlternateUnitZeroHandling);
+            return GetAlternateTextWithPostFix(m);
+        }
+
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <see cref="DimensionProperties.PlusTolerance" />
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearScaledAndRoundedTo"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.ToleranceDecimalPlaces"/>
+        /// <see cref="DimensionProperties.ToleranceZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>
+        /// </remarks>
+        public override string FormatMeasurementToleranceSymmetric() {
+            double tolerance = GetValueScaledAndRounded(_dimProps.PlusTolerance);
+            string m = FormatValue(tolerance, _dimProps.ToleranceDecimalPlaces, _dimProps.ToleranceZeroHandling);
+            return "±" + GetTextWithPostFix(m);
+
+        }
+
+
+        /// <summary>
+        /// Formats the alternate-unit tolerance value assuming that the <see cref="DimensionProperties.PlusTolreance"/>
+        /// and the <see cref="DimensionProperties.MinusTolreance"/> are equal. The formatted tolerance
+        /// value is prefixed with "±" and should follow the alternate-unit measurement value.
+        /// </summary>
+        /// <returns>A string containing the formatted alternate-unit tolerance value.</returns>
+        /// <remarks>
+        /// <see cref="DimensionProperties.PlusTolerance" />
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearAlternateScaledAndRoundedTo"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.AlternateUnitToleranceDecimalPlaces"/>
+        /// <see cref="DimensionProperties.AlternateUnitToleranceZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="alternatePostFix"]'/>
+        /// </remarks>
+        public virtual string FormatAlternateToleranceSymmetric() {
+            double alternateTolerance = GetAlternateValueScaledAndRounded(_dimProps.PlusTolerance);
+            string m = FormatValue(alternateTolerance, _dimProps.AlternateUnitToleranceDecimalPlaces, _dimProps.AlternateUnitToleranceZeroHandling);
+            return "±" + GetAlternateTextWithPostFix(m);
+        }
+
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <see cref="DimensionProperties.MinusTolerance" />, <see cref="DimensionProperties.PlusTolerance" />
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearScaledAndRoundedToPlural"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.ToleranceDecimalPlaces"/>
+        /// <see cref="DimensionProperties.ToleranceZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>
+        /// </remarks>
+        public override string FormatMeasurementTolerancePlusMinus() {
+            double minusTolerance = GetValueScaledAndRounded(_dimProps.MinusTolerance);
+            double plusTolerance = GetValueScaledAndRounded(_dimProps.PlusTolerance);
+
+            string minusToleranceFormatted = FormatValue(minusTolerance, _dimProps.DecimalPlaces, _dimProps.ZeroHandling);
+            string plusToleranceFormatted = FormatValue(plusTolerance, _dimProps.DecimalPlaces, _dimProps.ZeroHandling);
+
+            return FormatToleranceStacked(
+                "-" + GetTextWithPostFix(minusToleranceFormatted),
+                "+" + GetTextWithPostFix(plusToleranceFormatted));
+        }
+
+
+        /// <summary>
+        /// Formats the alternate-unit tolerance value assuming that the
+        /// <see cref="DimensionProperties.PlusTolreance"/> and the <see cref="DimensionProperties.MinusTolreance"/>
+        /// are not equal. The values are stacked, coded with AutoCAD-MTEXT markup-commands.
+        /// The <see cref="DimensionProperties.PlusTolreance"/> is placed above, prefixed with a "+" sign,
+        /// the <see cref="DimensionProperties.MinusTolreance"/> is placed below, prefixed with a "-" sign.
+        /// The formatted stacked alternate tolerance values should immediately follow the alternate value.
+        /// The text size of the stacked values is controlled by the
+        /// <see cref="DimensionProperties.ToleranceScaleFactor"/> property.
+        /// </summary>
+        /// <returns>A string containing the formatted stacked alternate-unit tolerance values.</returns>
+        /// <remarks>
+        /// <see cref="DimensionProperties.MinusTolerance" />, <see cref="DimensionProperties.PlusTolerance" />
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearAlternateScaledAndRoundedToPlural"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.AlternateUnitToleranceDecimalPlaces"/>
+        /// <see cref="DimensionProperties.AlternateUnitToleranceZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="alternatePostFix"]'/>
+        /// </remarks>
+        public virtual string FormatAlternateTolerancePlusMinus() {
+            double minusTolerance = GetAlternateValueScaledAndRounded(_dimProps.MinusTolerance);
+            double plusTolerance = GetAlternateValueScaledAndRounded(_dimProps.PlusTolerance);
+
+            string minusToleranceFormatted = FormatValue(minusTolerance, _dimProps.AlternateUnitDecimalPlaces, _dimProps.AlternateUnitZeroHandling);
+            string plusToleranceFormatted = FormatValue(plusTolerance, _dimProps.AlternateUnitDecimalPlaces, _dimProps.AlternateUnitZeroHandling);
+
+            return FormatToleranceStacked(
+                "-" + GetAlternateTextWithPostFix(minusToleranceFormatted),
+                "+" + GetAlternateTextWithPostFix(plusToleranceFormatted));
+        }
+
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The limits
+        /// (Measurement - <see cref="DimensionProperties.MinusTolerance" /> and
+        /// Measurement + <see cref="DimensionProperties.PlusTolerance" />)
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearScaledAndRoundedToPlural"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.DecimalPlaces"/>
+        /// <see cref="DimensionProperties.ZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="primaryPostFix"]'/>
+        /// </remarks>
+        public override string FormatMeasurementLimits() {
+            double minLimit = GetValueScaledAndRounded(_dimension.Measurement - _dimProps.MinusTolerance);
+            double maxLimit = GetValueScaledAndRounded(_dimension.Measurement + _dimProps.PlusTolerance);
+
+            short decimalPlaces = _dimProps.DecimalPlaces;
+            ZeroHandling zeroHandling = _dimProps.ZeroHandling;
+            string minLimitFormatted = FormatValue(minLimit, decimalPlaces, zeroHandling);
+            string maxLimitFormatted = FormatValue(maxLimit, decimalPlaces, zeroHandling);
+
+            return FormatToleranceStacked(
+                GetTextWithPostFix(minLimitFormatted),
+                GetTextWithPostFix(maxLimitFormatted));
+        }
+
+
+        /// <summary>
+        /// The alternate-unit tolerance is to be shown as a maximum and minimum value stacked, coded with AutoCAD-MTEXT
+        /// markup-commands. The maximum value (alternate-unit measurement + <see cref="DimensionProperties.PlusTolreance"/>)
+        /// is placed above the minimum value (alternate-unit measurement - <see cref="DimensionProperties.MinusTolreance"/>)
+        /// is placed below.
+        /// The text size of the stacked values is controlled by the
+        /// <see cref="DimensionProperties.ToleranceScaleFactor"/> property.
+        /// </summary>
+        /// <returns>A string containing the formatted stacked alternate-unit limits values.</returns>
+        /// <remarks>
+        /// The limits
+        /// Measurement - <see cref="DimensionProperties.MinusTolerance" />,
+        /// measurement + <see cref="DimensionProperties.PlusTolerance" />
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearAlternateScaledAndRoundedToPlural"]'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="linearFormattedAs"]'/>
+        /// <see cref="DimensionProperties.AlternateUniteDecimalPlaces"/> and
+        /// <see cref="DimensionProperties.AlternateUnitZeroHandling"/>.
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="alternatePostFix"]'/>
+        /// </remarks>
+        public virtual string FormatAlternateLimits() {
+            double minAlternateLimit = GetAlternateValueScaledAndRounded(_dimension.Measurement - _dimProps.MinusTolerance);
+            double maxAlternateLimit = GetAlternateValueScaledAndRounded(_dimension.Measurement + _dimProps.PlusTolerance);
+
+            short decimalPlaces = _dimProps.AlternateUnitDecimalPlaces;
+            ZeroHandling zeroHandling = _dimProps.AlternateUnitZeroHandling;
+            string minAlternateLimitFormatted = FormatValue(minAlternateLimit, decimalPlaces, zeroHandling);
+            string maxAlternateLimitFormatted = FormatValue(maxAlternateLimit, decimalPlaces, zeroHandling);
+
+            return FormatToleranceStacked(
+                GetAlternateTextWithPostFix(minAlternateLimitFormatted),
+                GetAlternateTextWithPostFix(maxAlternateLimitFormatted));
+        }
+
+
+        /// <summary>
+        /// Adds a prefix and/or a suffix specified by the <see cref="DimensionProperties.AlternateDimensioningSuffix"/>
+        /// property to the <paramref name="text"/>. If the <see cref="DimensionProperties.AlternateDimensioningSuffix"/>
+        /// is empty the default PostFix is used.
+        /// </summary>
+        /// <param name="text">A string the prefix and/or suffix is to be added to.</param>
+        /// <param name="defaultPostFix">Default prefix/suffix, to be used if the
+        /// <see cref="DimensionProperties.AlternateDimensioningSuffix"/> is empty.</param>
+        /// <returns>The <paramref name="text"/> with the prefix and/or suffix added.</returns>
+        protected string GetAlternateTextWithPostFix(string text) {
+            string defaultPostFix = _defaultPostFix.Replace("<>", "[]");
+            string postFix = _dimProps.AlternateDimensioningSuffix;
+            if (string.IsNullOrEmpty(postFix)) {
+                postFix = defaultPostFix;
+            }
+            else if (!postFix.Contains("[]")) {
+                postFix = "[]" + postFix;
+            }
+            return postFix.Replace("[]", text);
+        }
+
+
+        /// <summary>
+        /// Scales the specified measurement or tolerance value with the
+        /// <see cref="DimensionProperties.LinearScaleFactor"/>
+        /// </summary>
+        /// <param name="value">The value to be scaled.</param>
+        /// <returns>The scaled value.</returns>
+        protected double GetValueScaledAndRounded(double value) {
+            double measurementScaled = value * _dimProps.LinearScaleFactor;
+            return RoundByUnit(measurementScaled, _dimProps.Rounding);
+        }
+
+
+        /// <summary>
+        /// Scales the specified measurement or tolerance value with the
+        /// <see cref="DimensionProperties.LinearScaleFactor"/>.
+        /// To obtain the value in alternate units it is multiplied with the
+        /// <see cref="DimensionProperties.AlternateUnitScaleFactor"/>.
+        /// </summary>
+        /// <param name="value">The value to be scaled.</param>
+        /// <returns>The scaled value.</returns>
+        protected double GetAlternateValueScaledAndRounded(double value) {
+            double alternateMeasurementScaled = value * _dimProps.LinearScaleFactor * _dimProps.AlternateUnitScaleFactor;
+            return RoundByUnit(alternateMeasurementScaled, _dimProps.AlternateUnitRounding);
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/MeasurementFormatterBase.cs
+++ b/ACadSvg/DimensionTextFormatter/MeasurementFormatterBase.cs
@@ -1,0 +1,421 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using System.Globalization;
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+using SvgElements;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Base class for measurement formatters. Measurement formatters are used to create
+    /// the parts of the measurement text such as measurement value with or without
+    /// tolerance and optionally an alternate scaled measurement value with or without
+    /// tolerance. Various formatters can be applied according to the specified format
+    /// for linear dimension (see <see cref="LinearMeasurementFormatter"/>)
+    /// and angular dimensions (see <see cref="AngularMeasurementFormatter"/>)
+    /// respectively.
+    /// </summary>
+    internal abstract class MeasurementFormatterBase {
+
+        protected readonly Dimension _dimension;
+        protected readonly DimensionProperties _dimProps;
+        protected readonly string _defaultPostFix;
+        protected readonly double _textSize;
+
+
+        /// <summary>
+        /// Initializes a new instance of a measurement formatter.
+        /// </summary>
+        /// <param name="dimension">The <see cref="Dimension"/> object the dimension text is to be created for.</param>
+        /// <param name="dimProps">A <see cref="DimensionProperties"/> object providing all
+        /// dimension-style properties specufied in the <see cref="DimensionStyle"/> object
+        /// associated with the dimension object possibly overriden by the dimension object's
+        /// extended data.</param>
+        /// <param name="defaultPostFix">A string specifying a default prefix and/or postfix
+        /// used for both the primary and the alternate value if no prefix/postfix is specified
+        /// by the dimension-style properties.</param>
+        /// 
+        protected MeasurementFormatterBase(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize) {
+            _dimension = dimension;
+            _dimProps = dimProps;
+            _defaultPostFix = string.IsNullOrEmpty(defaultPostFix) ? "<>" : defaultPostFix;
+            _textSize = textSize;
+        }
+
+
+        /// <summary>
+        /// If implemented by a derived class converts the specified value into a string
+        /// in a specific format.
+        /// </summary>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="valueParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="zeroHandlingParameter"]/*'/>
+        /// <returns>The converted value in the specific format.</returns>
+        protected abstract string FormatValue(double value, short decimalplaces, ZeroHandling zeroHandling);
+
+
+        /// <summary>
+        /// Formats the (primary) measurement value. The formatted numerical value is prefixed and/or
+        /// suffixed as specified by the <see cref="DimensionProperties.PostFix"/> style property.
+        /// If no PostFix style property is specified the default Postfix specified for this formatter
+        /// is used.
+        /// </summary>
+        /// <returns>A string containing formatted measurement value.</returns>
+        public abstract string FormatMeasurement();
+
+
+        /// <summary>
+        /// Formats the tolerance value assuming that the <see cref="DimensionProperties.PlusTolreance"/>
+        /// and the <see cref="DimensionProperties.MinusTolreance"/> are equal. The formatted tolerance
+        /// value is prefixed with "±" and should follow the primary measurement value.
+        /// </summary>
+        /// <returns>A string containing the formatted tolerance value.</returns>
+        public abstract string FormatMeasurementToleranceSymmetric();
+
+
+        /// <summary>
+        /// Formats the a tolerance value assuming that the <see cref="DimensionProperties.PlusTolreance"/>
+        /// and the <see cref="DimensionProperties.MinusTolreance"/> are not equal. The values are stacked,
+        /// coded with AutoCAD-MTEXT markup-commands.
+        /// The <see cref="DimensionProperties.PlusTolreance"/> is placed above, prefixed with a "+" sign,
+        /// the <see cref="DimensionProperties.MinusTolreance"/> is placed below, prefixed with a "-" sign.
+        /// The formatted stacked tolerance values should immediately follow the primary measurement value.
+        /// </summary>
+        /// <returns>A string containing the formatted stacked tolerance values.</returns>
+        public abstract string FormatMeasurementTolerancePlusMinus();
+
+
+        /// <summary>
+        /// The tolerance is to be shown as a maximum and minimum value stacked coded with AutoCAD-MTEXT
+        /// markup-commands. The maximum value (measurement + <see cref="DimensionProperties.PlusTolreance"/>)
+        /// is placed above the minimum value (measurement - <see cref="DimensionProperties.MinusTolreance"/>)
+        /// is placed below.
+        /// The text size of the stacked values is controlled by the
+        /// <see cref="DimensionProperties.ToleranceScaleFactor"/> property.
+        /// </summary>
+        /// <param name="textSize"></param>
+        /// <returns>A string containing the formatted stacked limits values.</returns>
+        public abstract string FormatMeasurementLimits();
+
+
+        /// <summary>
+        /// Adds a prefix and/or a suffix specified by the <see cref="DimensionProperties.PostFix"/>
+        /// property to the <paramref name="text"/>. If the <see cref="DimensionProperties.PostFix"/>
+        /// is empty the default PostFix is used.
+        /// </summary>
+        /// <param name="text">A string the prefix and/or suffix is to be added to.</param>
+        /// <param name="defaultPostFix">Default prefix/suffix, to be used if the
+        /// <see cref="DimensionProperties.PostFix"/> is empty.</param>
+        /// <returns>The <paramref name="text"/> with the prefix and/or suffix added.</returns>
+        protected string GetTextWithPostFix(string text) {
+            string postFix = _dimProps.PostFix;
+            if (string.IsNullOrEmpty(postFix)) {
+                postFix = _defaultPostFix;
+            }
+            else if (!postFix.Contains("<>")) {
+                postFix = "<>" + postFix;
+            }
+            return postFix.Replace("<>", text);
+        }
+
+
+        /// <summary>
+        /// Rounds the specified value to the specified unit.
+        /// </summary>
+        /// <param name="value">The value to be rounded.</param>
+        /// <param name="roundingUnit"></param>
+        /// <returns>The rounded value.</returns>
+        protected static double RoundByUnit(double value, double roundingUnit) {
+            if (roundingUnit == 0) {
+                return value;
+            }
+            return Math.Round(value / roundingUnit, MidpointRounding.AwayFromZero) * roundingUnit;
+        }
+
+
+        /// <summary>
+        /// Formats the specified <paramref name="value"/> as decimal number using decimal separator specified
+        /// by <see cref="DimensionProperties.DecimalSeparator" /> and the specified <paramref name="decimalPlaces"/>
+        /// and <paramref name="zeroHandling"/>.
+        /// </summary>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="valueParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="zeroHandlingParameter"]/*'/>
+        /// <returns>
+        /// The formatted value as decimal number.
+        /// </returns>
+        protected string FormatDecimal(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            NumberFormatInfo nfi = new NumberFormatInfo();
+            nfi.NumberDecimalSeparator = _dimProps.DecimalSeparator.ToString();
+            string format = "F" + decimalPlaces.ToString();
+            return handleZerosDecimal(value.ToString(format, nfi), zeroHandling, _dimProps.DecimalSeparator);
+        }
+
+
+        /// <summary>
+        /// Formats the specified <paramref name="value"/> as decimal number as exponential expression
+        /// using decimal separator specified by <see cref="DimensionProperties.DecimalSeparator" />,
+        /// the specified <paramref name="decimalPlaces"/> and <paramref name="zeroHandling"/>.
+        /// </summary>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="valueParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="zeroHandlingParameter"]/*'/>
+        /// <returns>
+        /// The formatted value as decimal number as exponential expression.
+        /// </returns>
+        protected string FormatExponential(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            NumberFormatInfo nfi = new NumberFormatInfo();
+            nfi.NumberDecimalSeparator = _dimProps.DecimalSeparator.ToString();
+            string format = "E" + decimalPlaces.ToString();
+            return handleZerosDecimal(value.ToString(format, nfi), zeroHandling, _dimProps.DecimalSeparator);
+        }
+
+
+        /// <summary>
+        /// Formats the specified value as integer part and fraction. 
+        /// </summary>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="valueParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameterFraction"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="zeroHandlingParameter"]/*'/>
+        /// <returns>
+        /// The formatted value with integer part and fraction.
+        /// </returns>
+        protected static string FormatFractional(double value, short precision, ZeroHandling zeroHandling) {
+            int intPart = roundToIntegerForFraction(value, precision);
+            double fracPart = value - intPart;
+            return $"{intPart}{ToFraction(fracPart, precision)}";
+        }
+
+
+        /// <summary>
+        /// Formats the specified value (in inches) as feets and inches, and the fractional
+        /// part of the inches as fraction.
+        /// </summary> 
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="valueParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameterFraction"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="zeroHandlingParameter"]/*'/>
+        /// <returns>
+        /// The formatted value with feet, integer inches, and fraction.
+        /// </returns>
+        protected static string FormatInchesToFeetInchesFractional(double value, short precision, ZeroHandling zeroHandling) {
+            int feet = Convert.ToInt32(Math.Truncate(value / 12));
+            double fullinches = value - feet * 12;
+            int inches = roundToIntegerForFraction(fullinches, precision);
+            double fracInches = fullinches - inches;
+            string fracInchesStr = ToFraction(fracInches, precision);
+
+            return handleZerosFeetAndInchesFractional(feet, inches, fracInchesStr, zeroHandling);
+        }
+
+
+        /// <summary>
+        /// Formats the specified value (in inches) as feet and inches as decimal number.
+        /// </summary>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="valueParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="decimalPlacesParameter"]/*'/>
+        /// <include file='_comments.xml' path='docTokens/docToken[@name="zeroHandlingParameter"]/*'/>
+        /// <returns>
+        /// The formatted value with feet and inches as decimal number.
+        /// </returns>
+        protected string FormatInchesToFeetInchesDecimal(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            int feet = Convert.ToInt32(Math.Truncate(value / 12));
+            double fullinches = value - feet * 12;
+            int inches = Convert.ToInt32(Math.Truncate(fullinches));
+            string fullinchesStr = FormatDecimal(fullinches, decimalPlaces, zeroHandling);
+
+            return handleZerosFeetAndInchesDecimal(feet, inches, fullinchesStr, zeroHandling);
+        }
+
+
+        private static int roundToIntegerForFraction(double value, short precision) {
+            double fracHalfStep = 1 / Math.Pow(2, precision) / 2;
+            int inches = Convert.ToInt32(Math.Truncate(value + fracHalfStep));
+            return inches;
+        }
+
+
+        private static List<string[]> _fractions = new List<string[]>(8) {
+            new string[2] {
+                "",
+                "1/2"
+            },
+            new string[4] {
+                "",
+                "1/4", "1/2", "3/4"
+            },
+            new string[8] {
+                "",
+                "1/8", "1/4", "3/8", "1/2", "5/8", "3/4", "7/8"
+            },
+            new string[16] {
+                "",
+                "1/16", "1/8", "3/16", "1/4", "5/16", "3/8", "7/16", "1/2",
+                "9/16", "5/8", "11/16", "3/4", "13/16", "7/8", "15/16"
+            },
+            new string[32] {
+                "",
+                "1/32", "1/16", "3/32", "1/8", "5/32", "3/16", "7/32", "1/4",
+                "9/32", "5/16", "11/32", "3/8", "13/32", "7/16", "15/32", "1/2",
+                "17/32", "9/16", "19/32", "5/8", "21/32", "11/16", "23/32", "3/4",
+                "25/32", "13/16", "27/32", "7/8", "29/32", "15/16", "31/32"
+            },
+            new string[64] {
+                "",
+                "1/64", "1/32", "3/64", "1/16", "5/64", "3/32", "7/64", "1/8",
+                "9/64", "5/32", "11/64", "3/16", "13/64", "7/32", "15/64", "1/4",
+                "17/64", "9/32", "19/64", "5/16", "21/64", "11/32", "23/64", "3/8",
+                "25/64", "13/32", "27/64", "7/16", "29/64", "15/32", "31/64", "1/2",
+                "33/64", "17/32", "35/64", "9/16", "37/64", "19/32", "39/64", "5/8",
+                "41/64", "21/32", "43/64", "11/16", "45/64", "23/32", "47/64", "3/4",
+                "49/64", "25/32", "51/64", "13/16", "53/64", "27/32", "55/64", "7/8",
+                "57/64", "29/32", "59/64", "15/16", "61/64", "31/32", "63/64"
+            }
+            //  TODO Add arrays 128, 256
+        };
+
+
+        private static string ToFraction(double fraction, short precision) {
+            if (precision < 1) {
+                return string.Empty;
+            }
+            if (precision > 6) {
+                precision = 6;
+            }
+            double denominator = Math.Pow(2, precision);
+            int index = Convert.ToInt32(Math.Floor(fraction * denominator));
+
+            return _fractions[precision - 1][index];
+        }
+
+
+        private static void getSignAndNumber(string text, out string number, out string sign) {
+            number = text;
+            sign = string.Empty;
+            if (text.StartsWith("+") || text.StartsWith("-")) {
+                sign = text.Substring(0, 1);
+                number = text.Substring(1);
+            }
+        }
+
+
+        private static string handleZerosDecimal(string text, ZeroHandling zeroHandling, char decimalSeparator) {
+            switch (zeroHandling) {
+            case ZeroHandling.SuppressDecimalLeadingZeroes:
+                getSignAndNumber(text, out string number, out string sign);
+                return sign + number.TrimStart('0');
+
+            case ZeroHandling.SuppressDecimalTrailingZeroes:
+                return text.TrimEnd('0').TrimEnd(decimalSeparator);
+
+            case ZeroHandling.SuppressDecimalLeadingAndTrailingZeroes:
+                getSignAndNumber(text, out string number2, out string sign2);
+                return sign2 + number2.TrimStart('0').TrimEnd('0').TrimEnd(decimalSeparator);
+            }
+
+            return text;
+        }
+
+
+		private static string handleZerosFeetAndInchesFractional(int feet, int inches, string fracInches, ZeroHandling zeroHandling) {
+            bool showFeet = true;
+            bool showInches = true;
+            
+            switch (zeroHandling) {
+				case ZeroHandling.SuppressZeroFeetAndInches:
+                    showFeet = feet != 0;
+                    showInches = inches != 0;
+                    break;
+				case ZeroHandling.ShowZeroFeetAndInches:
+					break;
+				case ZeroHandling.ShowZeroFeetSuppressZeroInches:
+                    showInches = inches != 0;
+					break;
+				case ZeroHandling.SuppressZeroFeetShowZeroInches:
+                    showFeet = feet != 0;
+					break;
+			}
+
+            string output = string.Empty;
+            if (showFeet) {
+                output += $"{feet}'";
+            }
+            if (showInches) {
+                if (output.Length > 0) {
+                    output += "-";
+                }
+                output += $"{inches} {fracInches}\"";
+            }
+			return output;
+		}
+
+
+		private static string handleZerosFeetAndInchesDecimal(int feet, int inches, string fullinchesStr, ZeroHandling zeroHandling) {
+			bool showFeet = true;
+			bool showInches = true;
+
+			switch (zeroHandling) {
+				case ZeroHandling.SuppressZeroFeetAndInches:
+					showFeet = feet != 0;
+					showInches = inches != 0;
+					break;
+				case ZeroHandling.ShowZeroFeetAndInches:
+					break;
+				case ZeroHandling.ShowZeroFeetSuppressZeroInches:
+					showInches = inches != 0;
+					break;
+				case ZeroHandling.SuppressZeroFeetShowZeroInches:
+					showFeet = feet != 0;
+					break;
+			}
+
+			string output = string.Empty;
+			if (showFeet) {
+				output += $"{feet}'";
+			}
+			if (showInches) {
+				if (output.Length > 0) {
+					output += "-";
+				}
+				output += $"{fullinchesStr}\"";
+			}
+			return output;
+		}
+
+
+        /// <summary>
+        /// Creates a string containing stacked values <paramref name="plus"/> and <paramref name="minus"/>
+        /// coded with AutoCAD/MTEXT markup commands. Depending on the
+        /// <see cref="DimensionProperties.ToleranceScaleFactor"/> the text size is set.
+        /// </summary>
+        /// <param name="minus">String to be placed at bottom.</param>
+        /// <param name="plus">String to be placed at top.</param>
+        /// <returns>
+        /// A string containing the stacked-expression of <paramref name="plus"/> and <paramref name="minus"/>.
+        /// </returns>
+		protected string FormatToleranceStacked(string minus, string plus) {
+
+            double toleranceScaleFactor = _dimProps.ToleranceScaleFactor;
+
+            if (toleranceScaleFactor == 1) {
+                return $"\\S{plus}^{minus};";
+            }
+            else {
+                string brace = "{";
+                string ketce = "}";
+                string height = SvgElementBase.Cd(_textSize * toleranceScaleFactor / 1.5);
+                return $"{brace}\\H{height};\\S{plus}^{minus}; {ketce}";
+            }
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/RadiansMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/RadiansMeasurementFormatter.cs
@@ -1,0 +1,39 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for angular dimensions. The angle value is formatted as
+    /// decimal radians.
+    /// </summary>
+    internal class RadiansMeasurementFormatter : DecimalDegreesMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadiansMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc/>
+        public RadiansMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Returns the specified angle value from AutoCAD in radians without scaling.
+        /// </summary>
+        /// <param name="value">The angle value in radians as specified by AutoCAD.</param>
+        /// <returns>The angle in gradians.</returns>
+        protected override double GetDisplayValue(double value) {
+            return value;
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/ScientificMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/ScientificMeasurementFormatter.cs
@@ -1,0 +1,45 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using System.Globalization;
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for linear measurements. The value is formatted as
+    /// a decimal number as exponential expression.
+    /// </summary>
+    internal class ScientificMeasurementFormatter : LinearMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScientificMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc />
+        public ScientificMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Formats the value as a decimal number as exponential expression
+        /// (see <see cref="MeasurementFormatterBase.FormatExponential(double, short, ZeroHandling)"/>.
+        /// </summary>
+        /// <inheritdoc />
+        /// <returns>
+        /// The formatted value as decimal number as exponetial expression.
+        /// </returns>
+        protected override string FormatValue(double value, short decimalPlaces, ZeroHandling zeroHandling) {
+            return FormatExponential(value, decimalPlaces, zeroHandling);
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/SurveyorUnitsMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/SurveyorUnitsMeasurementFormatter.cs
@@ -1,0 +1,53 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for angular dimensions. The angle value is formatted in
+    /// surveyors units.
+    /// </summary>
+    /// <remarks>
+    /// <b>This formatter is not yet implemented.</b>
+    /// </remarks>
+    internal class SurveyorUnitsMeasurementFormatter : AngularMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="SurveyorUnitsMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc/>
+        public SurveyorUnitsMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// Scales the specified angle value from AutoCAD to degrees.
+        /// </summary>
+        /// <param name="value">The angle value in radians as specified by AutoCAD.</param>
+        /// <returns>The angle in degrees.</returns>
+        protected override double GetDisplayValue(double value) {
+            return value * 180 / Math.PI;
+        }
+
+
+        /// <summary>
+        /// This method is not yet implemented.
+        /// </summary>
+        /// <inheritdoc/>
+        /// <exception cref="NotImplementedException"></exception>
+        protected override string FormatValue(double value, short decimalplaces, ZeroHandling zeroHandling) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/WindowsDesktopMeasurementFormatter.cs
+++ b/ACadSvg/DimensionTextFormatter/WindowsDesktopMeasurementFormatter.cs
@@ -1,0 +1,42 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+using ACadSharp.Entities;
+using ACadSharp.Tables;
+
+using ACadSvg.Extensions;
+
+
+namespace ACadSvg.DimensionTextFormatter {
+
+    /// <summary>
+    /// Represents a formatter for linear measurements.
+    /// </summary>
+    /// <remarks>
+    /// <b>This formatter is not yet implemented.</b>
+    /// </remarks>
+    internal class WindowsDesktopMeasurementFormatter : LinearMeasurementFormatter {
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="WindowsDesktopMeasurementFormatter"/>.
+        /// </summary>
+        /// <inheritdoc/>
+        public WindowsDesktopMeasurementFormatter(Dimension dimension, DimensionProperties dimProps, string defaultPostFix, double textSize)
+            : base(dimension, dimProps, defaultPostFix, textSize) {
+        }
+
+
+        /// <summary>
+        /// This method is not yet implemented.
+        /// </summary>
+        /// <inheritdoc/>
+        /// <exception cref="NotImplementedException"></exception>
+        protected override string FormatValue(double value, short decimalplaces, ZeroHandling zeroHandling) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ACadSvg/DimensionTextFormatter/_comments.xml
+++ b/ACadSvg/DimensionTextFormatter/_comments.xml
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<docTokens>
+
+  <docToken name="valueParameter">
+    <param name="value">The value to be converted.</param>
+  </docToken>
+  <docToken name="decimalPlacesParameter">
+    <param name="decimalplaces">A value indicating the precision of the converted value.</param>
+  </docToken>
+  <docToken name="decimalPlacesParameterFraction">
+    <param name="precision">
+      Indicates the precision of the converted value. This
+      parameter specifies the denominator of the fraction (1: 1/2, 2: 1/4, 3: 1/8, etc.).
+    </param>
+  </docToken>
+  <docToken name="zeroHandlingParameter">
+    <param name="zeroHandling">A value indicating how the leading and trailing zeroes are to be handled.</param>
+  </docToken>
+
+  <docToken name="linearScaledAndRoundedTo">
+    is scaled with the <see cref="DimensionProperties.LinearScaleFactor" />
+    and rounded using <see cref="DimensionProperties.Rounding" />
+  </docToken>
+
+  <docToken name="linearAlternateScaledAndRoundedTo">
+    scaled with the <see cref="DimensionProperties.LinearScaleFactor" /> is scaled
+    to alternate units with <see cref="DimensionProperties.AlternateUnitScaleFactor" />.
+    The scaled value is rounded using <see cref="DimensionProperties.Rounding" />
+  </docToken>
+
+  <docToken name="linearScaledAndRoundedToPlural">
+    are scaled with the <see cref="DimensionProperties.LinearScaleFactor" />
+    and rounded using <see cref="DimensionProperties.Rounding" />
+  </docToken>
+
+  <docToken name="linearAlternateScaledAndRoundedToPlural">
+    scaled with the <see cref="DimensionProperties.LinearScaleFactor" /> are scaled
+    to alternate units with <see cref="DimensionProperties.AlternateUnitScaleFactor" />.
+    The scaled values are rounded using <see cref="DimensionProperties.Rounding" />
+  </docToken>
+
+
+  <docToken name="linearFormattedAs">
+    and formatted to the specific linear format (<see cref="FormatValue" />) using
+  </docToken>
+
+  <docToken name="angularScaledTo">
+    from AutoCAD in radians is scaled to the specific angular unit (<see cref="GetDisplayValue" />)
+  </docToken>
+  <docToken name="angularScaledToPlural">
+    from AutoCAD in radians are scaled to the specific angular unit (<see cref="GetDisplayValue" />)
+  </docToken>
+
+  <docToken name="angularFormattedAs">
+    and formatted to the specific angular format (<see cref="FormatValue" />)
+  </docToken>
+
+
+  <docToken name="primaryPostFix">
+    Prefix and/or suffix (<see cref="DimensionProperties.PostFix" />) or,
+    if not specified, the default PostFix is added.
+  </docToken>
+
+  <docToken name="alternatePostFix">
+    Prefix and/or suffix (<see cref="DimensionProperties.AlternateDimensioningSuffix" />) or,
+    if not specified, the default PostFix is added.
+  </docToken>
+
+</docTokens>


### PR DESCRIPTION
This PR adds the namespace `ACadSvg.DimensionTextFormatter` and formatter classes, without using them.